### PR TITLE
added public-ui volume and replaced npm with yarn in sample_docker_pr…

### DIFF
--- a/docs/samples/sample_docker_prod_remote_db.yml
+++ b/docs/samples/sample_docker_prod_remote_db.yml
@@ -11,9 +11,11 @@ services:
       env_prod.list
   web:
     image: openeats/openeats-web
-    command: npm start
+    command: yarn start
     depends_on:
       - api
+    volumes:
+      - public-ui:/code/build
     env_file:
       env_prod.list
   nginx:
@@ -22,11 +24,13 @@ services:
     volumes:
       - static-files:/var/www/html/openeats-static/static-files
       - site-media:/var/www/html/openeats-static/site-media
+      - public-ui:/var/www/html/openeats-static/public-ui
     depends_on:
       - api
       - web
     env_file:
       env_prod.list
 volumes:
+  public-ui:
   static-files:
   site-media:


### PR DESCRIPTION
Hi

I noticed the sample config wasn't using the volumes - so the work the web container was doing wasn't being picked up by the nginx one.

I simply aligned the sample with the root `docker_prod.yml`

-R