### PR TITLE
Fix persistence for DB container.

### DIFF
--- a/docker-prod.yml
+++ b/docker-prod.yml
@@ -23,6 +23,8 @@ services:
       env_prod.list
   db:
     image: mariadb:5.5.64
+    volumes:
+      - database:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 20s

--- a/docker-stage.yml
+++ b/docker-stage.yml
@@ -23,6 +23,8 @@ services:
       env_stg.list
   db:
     image: mariadb
+    volumes:
+      - database:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 20s


### PR DESCRIPTION
The database is currently not persisted in a docker volume, although the volume `database` exists. Thus, when the container `db` is removed, the whole database is lost (unless you have a backup).

This looks like a migration bug since in the legacy `docker-compose.yml` file it is still in. In `docker-{prod,stage}.yml`, it is missing, though.