### PR TITLE
Generate correct absolute URLs in openeats-api

### DIFF
--- a/docs/Running_the_App_Without_Docker.md
+++ b/docs/Running_the_App_Without_Docker.md
@@ -169,6 +169,10 @@ DATABASES = {
 }
 ```
 Edit this to include the same options you set in your `.env`.
+If you are using the api behind a reverse proxy, as in this guide, then the following line should be added to the settings file in order for the api to generate the correct absolute URI's:
+```
+USE_X_FORWARDED_HOST = True
+```
 
 ### Edit the /opt/openeats/openeats-api/base/gunicorn_start.sh file
 


### PR DESCRIPTION
The openeats-api generates absolute URLs for uploaded images. Without USE_X_FORWARDED_HOST it uses the IP and port gunicorn runs on (127.0.0.1:5210) instead of the fqdn of the reverse proxy for these URLs.

This fixes the following issue in the openeats -web repo:
https://github.com/open-eats/openeats-web/issues/56